### PR TITLE
Shrink expedition member icons

### DIFF
--- a/ProjectChimera/GuildMasterView.swift
+++ b/ProjectChimera/GuildMasterView.swift
@@ -2315,19 +2315,23 @@ struct ActiveExpeditionCard: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                 
-                ForEach(expeditionMembers, id: \.id) { member in
+                if let firstRole = expeditionMembers.first?.role {
                     HStack(spacing: 4) {
-                        Image(systemName: memberRoleIcon(for: member.role))
-                            .font(.caption)
-                            .foregroundColor(memberRoleColor(for: member.role))
-                        
-                        Text(member.name)
-                            .font(.caption)
+                        Image(systemName: memberRoleIcon(for: firstRole))
+                            .font(.caption2)
+                            .foregroundColor(memberRoleColor(for: firstRole))
+                        Text("×\(expeditionMembers.count)")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
                     }
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
-                    .background(memberRoleColor(for: member.role).opacity(0.2))
+                    .background(memberRoleColor(for: firstRole).opacity(0.2))
                     .cornerRadius(4)
+                } else {
+                    Text("None")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
                 }
             }
             


### PR DESCRIPTION
Condense expedition member icons into a single compact icon with a multiplier to reduce UI clutter.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4c5d278-8054-4492-bfa7-a6cac2a8de34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4c5d278-8054-4492-bfa7-a6cac2a8de34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

