### PR TITLE
Fix spells tab ui display

### DIFF
--- a/ProjectChimera/Managers.swift
+++ b/ProjectChimera/Managers.swift
@@ -116,14 +116,37 @@ extension SpellEffect {
         switch self {
         case .doubleXP: return "Double XP"
         case .doubleGold: return "Double Gold"
-        case .xpBoost(let stat, let multiplier): return "+\(Int(multiplier * 100))% \(stat.rawValue.capitalized) XP"
-        case .goldBoost(let multiplier): return "+\(Int(multiplier * 100))% Gold"
-        case .runeBoost(let multiplier): return "+\(Int(multiplier * 100))% Runes"
-        case .willpowerGeneration(let amount): return "+\(amount) Willpower/min"
-        case .reducedUpgradeCost(let percentage): return "-\(Int(percentage * 100))% Upgrade Cost"
-        case .guildXpBoost(let multiplier): return "+\(Int(multiplier * 100))% Guild XP"
-        case .plantGrowthSpeed(let multiplier): return "+\(Int(multiplier * 100))% Plant Growth"
-        case .echoBoost(let multiplier): return "+\(Int(multiplier * 100))% Echoes"
+        case .xpBoost(let stat, let multiplier):
+            let pct = multiplier >= 1.0 ? (multiplier - 1.0) : multiplier
+            return "+\(Int(pct * 100))% \(stat.rawValue.capitalized) XP"
+        case .goldBoost(let multiplier):
+            let pct = multiplier >= 1.0 ? (multiplier - 1.0) : multiplier
+            return "+\(Int(pct * 100))% Gold"
+        case .runeBoost(let multiplier):
+            let pct = multiplier >= 1.0 ? (multiplier - 1.0) : multiplier
+            return "+\(Int(pct * 100))% Runes"
+        case .willpowerGeneration(let amount):
+            return "+\(amount) Willpower/min"
+        case .reducedUpgradeCost(let value):
+            // Accept both semantics: value as delta (0.05 => 5%) or as multiplier (0.90 => 10%)
+            let pct: Double
+            if value <= 0.5 {
+                pct = value
+            } else if value < 1.0 {
+                pct = 1.0 - value
+            } else {
+                pct = 0.0
+            }
+            return "-\(Int(pct * 100))% Upgrade Cost"
+        case .guildXpBoost(let multiplier):
+            let pct = multiplier >= 1.0 ? (multiplier - 1.0) : multiplier
+            return "+\(Int(pct * 100))% Guild XP"
+        case .plantGrowthSpeed(let multiplier):
+            let pct = multiplier >= 1.0 ? (multiplier - 1.0) : multiplier
+            return "+\(Int(pct * 100))% Plant Growth"
+        case .echoBoost(let multiplier):
+            let pct = multiplier >= 1.0 ? (multiplier - 1.0) : multiplier
+            return "+\(Int(pct * 100))% Echoes"
         }
     }
     var systemImage: String {

--- a/ProjectChimera/SpellbookView.swift
+++ b/ProjectChimera/SpellbookView.swift
@@ -86,36 +86,55 @@ struct SpellbookView: View {
     }
 
     // MARK: - Book Layout
-
+    
     private var openBook: some View {
         GeometryReader { proxy in
             let width = proxy.size.width
-            let pageWidth = min(600.0, width - 32) // keep nice margins
-
+            let isWide = width >= 700
+            let pageWidth = min(isWide ? 1000.0 : width - 32, width - 32)
+            
             VStack(spacing: 16) {
                 // Book spine tabs / filters
                 filterTabs
-
-                ZStack {
-                    RoundedRectangle(cornerRadius: 22)
-                        .fill(.thinMaterial)
-                        .overlay(bookTextureInset)
-                        .shadow(color: .black.opacity(0.25), radius: 16, x: 0, y: 10)
-
-                    // Two-page layout
-                    HStack(spacing: 0) {
-                        bookPageLeft
-                            .frame(width: pageWidth/2)
-                            .padding(.leading, 18)
-                            .padding(.vertical, 18)
-                        Divider().blendMode(.overlay)
-                        bookPageRight
-                            .frame(width: pageWidth/2)
-                            .padding(.trailing, 18)
-                            .padding(.vertical, 18)
+                
+                if isWide {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 22)
+                            .fill(.thinMaterial)
+                            .overlay(bookTextureInset)
+                            .shadow(color: .black.opacity(0.25), radius: 16, x: 0, y: 10)
+                        
+                        // Two-page layout
+                        HStack(spacing: 0) {
+                            bookPageLeft
+                                .frame(width: pageWidth/2)
+                                .padding(.leading, 18)
+                                .padding(.vertical, 18)
+                            Divider().blendMode(.overlay)
+                            bookPageRight
+                                .frame(width: pageWidth/2)
+                                .padding(.trailing, 18)
+                                .padding(.vertical, 18)
+                        }
                     }
+                    .frame(width: pageWidth, alignment: .center)
+                } else {
+                    // Compact: stack pages vertically within the same styled container
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 22)
+                            .fill(.thinMaterial)
+                            .overlay(bookTextureInset)
+                            .shadow(color: .black.opacity(0.25), radius: 16, x: 0, y: 10)
+                        
+                        VStack(alignment: .leading, spacing: 18) {
+                            bookPageLeft
+                            Divider().blendMode(.overlay)
+                            bookPageRight
+                        }
+                        .padding(18)
+                    }
+                    .frame(width: pageWidth, alignment: .center)
                 }
-                .frame(width: pageWidth, alignment: .center)
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 8)


### PR DESCRIPTION
Implement adaptive spellbook UI layout and correct spell effect percentage displays.

The previous spellbook UI forced a two-page layout even on compact screens, leading to a broken, vertically stacked appearance. This PR introduces a responsive layout that displays two pages on wide screens and a single, stacked page on compact screens. It also standardizes the display of spell effect percentages, correctly handling both delta and multiplier values.

---
<a href="https://cursor.com/background-agent?bcId=bc-cdd6470e-495f-4b6a-ac06-9578c97f9d02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cdd6470e-495f-4b6a-ac06-9578c97f9d02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

