### PR TITLE
Fix chimera lair ui overlap and mess

### DIFF
--- a/ProjectChimera/LairView.swift
+++ b/ProjectChimera/LairView.swift
@@ -21,10 +21,9 @@ struct LairView: View {
                     if let user = user, let chimera = user.chimera {
                         GlassCard {
                             VStack(alignment: .leading, spacing: 14) {
-                                header
-                                equippedSection(chimera: chimera)
-                                
-                                Group {
+                                                                 equippedSection(chimera: chimera)
+                                 
+                                 Group {
                                     switch activeTab {
                                     case .wardrobe:
                                         WardrobePanel(chimera: chimera)
@@ -60,11 +59,12 @@ struct LairView: View {
                         .padding(.horizontal)
                     }
                 }
-                .padding(.top, 8)
-                .padding(.bottom, 140) // leave room for bottom inset tabs
+                .padding(.top, 80) // give breathing room below the HUD
+                .padding(.bottom, 120) // leave room for bottom inset tabs
             }
             .scrollIndicators(.hidden)
         }
+        .navigationBarTitleDisplayMode(.inline)
         .navigationTitle("Chimera's Lair")
         .onAppear { loadUser() }
         .safeAreaInset(edge: .top) {


### PR DESCRIPTION
Refactor Chimera's Lair UI to prevent overlapping elements and improve readability.

The previous layout caused the navigation bar title, in-card header, top HUD, and bottom tab bar to overlap, obscuring content. This PR resolves these issues by removing redundant elements and adjusting spacing.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea8ec8c6-e69f-438d-b084-6d74fd2ef6d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea8ec8c6-e69f-438d-b084-6d74fd2ef6d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

