### PR TITLE
Stabilize chimera's lair ui elements

### DIFF
--- a/ProjectChimera/LairSpectacularUI.swift
+++ b/ProjectChimera/LairSpectacularUI.swift
@@ -123,6 +123,7 @@ struct ProgressBar: View {
 
 struct GlowButtonStyle: ButtonStyle {
     var gradient: LinearGradient = GameTheme.okGradient
+    var animatedSheen: Bool = true
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.system(.headline, design: .rounded))
@@ -136,7 +137,16 @@ struct GlowButtonStyle: ButtonStyle {
             )
             .shadow(color: .black.opacity(0.4), radius: 18, y: 10)
             .scaleEffect(configuration.isPressed ? 0.98 : 1)
-            .overlay(AnimatedSheen().clipShape(RoundedRectangle(cornerRadius: 18)))
+            .overlay(
+                Group {
+                    if animatedSheen {
+                        AnimatedSheen()
+                    } else {
+                        StaticSheen()
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+            )
     }
 }
 
@@ -157,6 +167,20 @@ struct AnimatedSheen: View {
         }
         .blendMode(.screen)
         .opacity(0.5)
+    }
+}
+
+struct StaticSheen: View {
+    var body: some View {
+        LinearGradient(stops: [
+            .init(color: .white.opacity(0.0), location: 0.0),
+            .init(color: .white.opacity(0.25), location: 0.5),
+            .init(color: .white.opacity(0.0), location: 1.0)
+        ], startPoint: .top, endPoint: .bottom)
+        .frame(width: 40)
+        .offset(x: 0)
+        .blendMode(.screen)
+        .opacity(0.18)
     }
 }
 

--- a/ProjectChimera/LairView.swift
+++ b/ProjectChimera/LairView.swift
@@ -148,7 +148,7 @@ struct LairView: View {
                 Text("25")
             }
         }
-        .buttonStyle(GlowButtonStyle())
+        .buttonStyle(GlowButtonStyle(animatedSheen: false))
         .padding(.horizontal, 14)
         .padding(.bottom, 16)
     }
@@ -224,11 +224,11 @@ private struct WardrobePanel: View {
             // Quick Actions
             HStack(spacing: 10) {
                 Button("Randomize") { randomizeAppearance() }
-                    .buttonStyle(GlowButtonStyle(gradient: GameTheme.infoGradient))
+                    .buttonStyle(GlowButtonStyle(gradient: GameTheme.infoGradient, animatedSheen: false))
                 Button("Reset") { resetAppearance() }
-                    .buttonStyle(GlowButtonStyle(gradient: GameTheme.okGradient))
+                    .buttonStyle(GlowButtonStyle(gradient: GameTheme.okGradient, animatedSheen: false))
                 Button("Toggle Hat") { toggleCosmetic() }
-                    .buttonStyle(GlowButtonStyle(gradient: GameTheme.infoGradient))
+                    .buttonStyle(GlowButtonStyle(gradient: GameTheme.infoGradient, animatedSheen: false))
             }
         }
         .foregroundStyle(GameTheme.textPrimary)


### PR DESCRIPTION
Adds option to disable animated sheen on buttons and applies it to LairView to keep UI elements static.

---
<a href="https://cursor.com/background-agent?bcId=bc-4476b066-3a33-4d27-9914-ee097b967a99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4476b066-3a33-4d27-9914-ee097b967a99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

