### PR TITLE
Fix ui animation and overlapping elements

### DIFF
--- a/ProjectChimera/LairSpectacularUI.swift
+++ b/ProjectChimera/LairSpectacularUI.swift
@@ -48,6 +48,8 @@ struct CurrencyBadge: View {
             }
             Text("\(amount)")
                 .font(.system(.headline, design: .rounded)).monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
                 .foregroundStyle(GameTheme.textPrimary)
         }
         .padding(.vertical, 6).padding(.horizontal, 10)

--- a/ProjectChimera/LairView.swift
+++ b/ProjectChimera/LairView.swift
@@ -59,7 +59,7 @@ struct LairView: View {
                         .padding(.horizontal)
                     }
                 }
-                .padding(.top, 80) // give breathing room below the HUD
+                .padding(.top, 120) // give breathing room below the HUD
                 .padding(.bottom, 120) // leave room for bottom inset tabs
             }
             .scrollIndicators(.hidden)
@@ -107,12 +107,15 @@ struct LairView: View {
                 Text(chimera.name).font(.headline).foregroundStyle(GameTheme.textPrimary)
                 Text("Discipline \(chimera.discipline) • Mindfulness \(chimera.mindfulness)")
                     .font(.footnote).foregroundStyle(GameTheme.textSecondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
                 ProgressBar(progress: upgradeProgress)
                     .frame(height: 10)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
+                // Move aura chip below to avoid horizontal crowding on small widths
+                Chip(text: "Aura: \(chimera.auraEffectID.capitalized.replacingOccurrences(of: "_", with: " "))")
             }
-            Spacer()
-            Chip(text: "Aura: \(chimera.auraEffectID.capitalized.replacingOccurrences(of: "_", with: " "))")
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(14)
         .background(GameTheme.panelFill, in: RoundedRectangle(cornerRadius: 16))


### PR DESCRIPTION
Stop UI elements from moving in Chimera's Lair and resolve overlapping header numbers.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8e720de-9f4d-4296-8aa6-43c99a3962dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8e720de-9f4d-4296-8aa6-43c99a3962dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

