### PR TITLE
Troubleshoot ui overlaps for habit garden

### DIFF
--- a/ProjectChimera/SanctuaryFeatureViews.swift
+++ b/ProjectChimera/SanctuaryFeatureViews.swift
@@ -52,7 +52,9 @@ public struct HabitGardenView: View {
                     }
                     .padding(.horizontal)
                 }
-                .padding(.vertical, 18)
+                // Add headroom so content never overlaps the top HUD or nav bar
+                .padding(.top, 96)
+                .padding(.bottom, 120)
             }
         }
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
Add top and bottom padding to the Habit Garden scroll view to prevent content from overlapping the HUD and tab bar.

---
<a href="https://cursor.com/background-agent?bcId=bc-95b95753-cf06-4950-8487-c4c7582f7bf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95b95753-cf06-4950-8487-c4c7582f7bf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

