### PR TITLE
Fix ui scrolling in chimera's lair

### DIFF
--- a/ProjectChimera/LairSpectacularUI.swift
+++ b/ProjectChimera/LairSpectacularUI.swift
@@ -26,9 +26,9 @@ struct GlassCard<Content: View>: View {
                 .fill(GameTheme.panelFill)
             RoundedRectangle(cornerRadius: corner)
                 .stroke(GameTheme.panelStroke, lineWidth: 1)
+            content()
         }
         .background(.black.opacity(0.001))
-        .overlay(content())
     }
 }
 


### PR DESCRIPTION
Fixes Lair UI scrolling by allowing `GlassCard` to size correctly based on its content.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c63fb14-dab7-41f9-9571-08dcc74f875d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c63fb14-dab7-41f9-9571-08dcc74f875d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

